### PR TITLE
5 configure and deploy new pythonfastapi service to aws

### DIFF
--- a/infra/terraform/tc-skills-service-test/main.tf
+++ b/infra/terraform/tc-skills-service-test/main.tf
@@ -7,7 +7,7 @@ module tc-test {
   fargate_cpu = 512
   fargate_memory = 2048
   dns_namespace = "tc-skills-extraction.local"
-  app_port = 8083
+  app_port = 8000
   health_check_path = "/readyz"
   tc_skills_base_url = "https://tctalent-test.org/api/public/skill/names"
   acm_certificate_arn = "arn:aws:acm:us-east-1:231168606641:certificate/3a502945-f505-46f9-aa08-523c2be2593d"


### PR DESCRIPTION
Small PR fixes typo in skills base url and changes app port to 8000 to match the service port