### PR TITLE
3160 migrate staging services to opc accounts

### DIFF
--- a/infra/terraform/acm.tf
+++ b/infra/terraform/acm.tf
@@ -13,6 +13,23 @@ resource "aws_acm_certificate" "this" {
   tags = local.tags
 }
 
+# DNS validation records for ACM certificate
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
 # Waits for DNS validation to complete before the certificate is usable
 resource "aws_acm_certificate_validation" "this" {
   certificate_arn         = aws_acm_certificate.this.arn

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -8,19 +8,23 @@ resource "aws_route53_zone" "this" {
   tags = local.tags
 }
 
-# DNS validation records for ACM certificate
-resource "aws_route53_record" "certificate_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
-    }
-  }
-
+# A record pointing the domain to the ALB
+resource "aws_route53_record" "ipv4" {
   zone_id = aws_route53_zone.this.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  ttl     = 60
-  records = [each.value.record]
+  name    = var.site_domain
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "www"
+  type    = "CNAME"
+  ttl     = "600"
+  records = [var.site_domain]
 }

--- a/infra/terraform/tc-skills-service-opc-prod/main.tf
+++ b/infra/terraform/tc-skills-service-opc-prod/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 # tc-skills-extraction infrastructure for OPC AWS production account
-module tc-opc-prod {
+module "tc-opc-prod" {
   source = "./.."
 
   # Provided as Terraform inputs

--- a/infra/terraform/tc-skills-service-opc-prod/main.tf
+++ b/infra/terraform/tc-skills-service-opc-prod/main.tf
@@ -29,7 +29,7 @@ module tc-opc-prod {
   site_domain         = "skills.plus.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
-  tc_skills_base_url  = "https://skills.plus.tctalent.org/api/public/skill/names"
+  tc_skills_base_url  = "https://plus.tctalent.org/api/public/skill/names"
 }
 
 # Configure the opc-production terraform workspace

--- a/infra/terraform/tc-skills-service-opc-test/main.tf
+++ b/infra/terraform/tc-skills-service-opc-test/main.tf
@@ -29,7 +29,7 @@ module tc-opc-test {
   site_domain         = "test.skills.plus.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
-  tc_skills_base_url  = "https://test.skills.plus.tctalent.org/api/public/skill/names"
+  tc_skills_base_url  = "https://test.plus.tctalent.org/api/public/skill/names"
 }
 
 # Configure the opc-staging terraform workspace

--- a/infra/terraform/tc-skills-service-opc-test/main.tf
+++ b/infra/terraform/tc-skills-service-opc-test/main.tf
@@ -29,7 +29,7 @@ module "tc-opc-test" {
   site_domain         = "test.skills.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
-  tc_skills_base_url  = "https://test.plus.tctalent.org/api/public/skill/names"
+  tc_skills_base_url  = "https://tctalent-test.org/api/public/skill/names"
 }
 
 # Configure the opc-staging terraform workspace

--- a/infra/terraform/tc-skills-service-opc-test/main.tf
+++ b/infra/terraform/tc-skills-service-opc-test/main.tf
@@ -26,7 +26,7 @@ module "tc-opc-test" {
   dns_namespace       = "tc-skills-extraction.local"
   app_port            = 8000
   health_check_path   = "/readyz"
-  site_domain         = "test.skills.plus.tctalent.org"
+  site_domain         = "test.skills.tctalent.org"
 
   # SSM-backed (stored in SSM, injected into ECS task)
   tc_skills_base_url  = "https://test.plus.tctalent.org/api/public/skill/names"

--- a/infra/terraform/tc-skills-service-opc-test/main.tf
+++ b/infra/terraform/tc-skills-service-opc-test/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 # tc-skills-extraction infrastructure for OPC AWS staging account
-module tc-opc-test {
+module "tc-opc-test" {
   source = "./.."
 
   # Provided as Terraform inputs


### PR DESCRIPTION
This PR builds on #20 

Once that is approved and merged then this PR will have only a single file change -- opc-staging/main.tf

1. the domain is updated from test.skills.plus.tctalent.org to test.skills.tctalent.org
2. the tc_skills_base_url is updated from https://test.plus.tctalent.org/api/public/skill/names to https://tctalent-test.org/api/public/skill/names

The changes have already been applied to opc-staging via terraform.

The Skills service has been tested and verified on OPC AWS.
 
The legacy Skills staging service has been switched off.